### PR TITLE
优化了 EditView 保存后的处理逻辑，解决一些跳转问题

### DIFF
--- a/src/mixins/app.js
+++ b/src/mixins/app.js
@@ -85,7 +85,7 @@ export default {
       const title = await vm.finalize(route.meta && route.meta.title, params)
       vm.$store.commit('replacePage', { name, params, query, title, meta: route.meta })
     },
-    closePage (index) {
+    async closePage (index) {
       const vm = this
       // let pagesOpened = vm.$store.state.app.pagesOpened
       // let lastPageObj = pagesOpened[0]
@@ -99,16 +99,21 @@ export default {
       if (isCurrentPageClosing) {
         // 没有了就打开首页
         if (vm.$store.state.app.pagesOpened.length === 0) {
-          vm.$router.push(vm.config.home_route)
+          await vm.$router.push(vm.config.home_route).catch(err => {
+            if (err.name !== 'NavigationDuplicated') throw err
+          })
         } else {
-          vm.$router.push(
-            vm.$store.state.app.pagesOpened[vm.$store.state.app.currentPageIndex].route)
+          await vm.$router.push(
+            vm.$store.state.app.pagesOpened[vm.$store.state.app.currentPageIndex].route
+          ).catch(err => {
+            if (err.name !== 'NavigationDuplicated') throw err
+          })
         }
       }
     },
-    closeCurrentPage () {
+    async closeCurrentPage () {
       const vm = this
-      vm.closePage(vm.$store.state.app.currentPageIndex)
+      await vm.closePage(vm.$store.state.app.currentPageIndex)
     }
   }
 }

--- a/src/plugins/data-view/components/EditView.vue
+++ b/src/plugins/data-view/components/EditView.vue
@@ -16,7 +16,7 @@
                   @click="save">保存并继续编辑
         </i-button>
         <i-button v-if="$refs.form && (options.can_edit === void 0 || finalizeSync(options.can_edit, $refs.form.item))"
-                  type="primary" @click="submit">保存
+                  type="primary" @click="submit">保存并关闭
         </i-button>
         <i-button v-if="isNaN(Number($route.params.id)) ? String($route.params.id) : Number($route.params.id) && $refs.form &&
                         (options.can_delete === void 0 || finalizeSync(options.can_delete, $refs.form.item))"
@@ -82,36 +82,39 @@
         const vm = this
         const form = await vm.waitFor(vm.$refs, 'form')
         if (vm.editViewOptions.options.onRefresh) {
-          vm.editViewOptions.options.onRefresh.apply(vm, vm.item)
+          await vm.editViewOptions.options.onRefresh.apply(vm, vm.item)
         } else {
           await form.reload()
         }
       },
       async save () {
-        // TODO: 提交之前应该实现 validate 验证方法，以校验 required 等字段的情况
         const vm = this
         const isCreate = !vm.$refs.form.id_
+        // 提交之前 validate 验证，以校验 required 等字段的情况
         await vm.validate()
         await vm.$refs.form.save()
         // 保存之后
         if (isCreate) {
           // 如果是创建要跳转页面
           const route = await vm.getModelEditRoute(vm.model, vm.$refs.form.id_)
+          await vm.closeCurrentPage()
+          await vm.$router.replace(route).catch(() => {}) // Silent Redundant Page Redirect
           await vm.replacePage(route)
-          vm.$router.push(route)
+        } else {
+          await vm.refresh()
         }
-        await vm.refresh()
       },
       async submit () {
         const vm = this
         await vm.save()
-        vm.closeCurrentPage()
+        await vm.$nextTick()
+        await vm.closeCurrentPage()
       },
       async remove () {
         const vm = this
         await vm.$confirm('确认删除？')
         await vm.$refs.form.deleteItem()
-        vm.closeCurrentPage()
+        await vm.closeCurrentPage()
       },
       async validate () {
         const vm = this

--- a/src/plugins/data-view/components/EditViewForm.vue
+++ b/src/plugins/data-view/components/EditViewForm.vue
@@ -65,7 +65,6 @@
     },
     methods: {
       async reload () {
-        console.log('>>> Form Reload!')
         const vm = this
         // 要支持外部更新 id 之后重载内容
         vm.id_ = vm.id

--- a/src/plugins/data-view/components/EditViewForm.vue
+++ b/src/plugins/data-view/components/EditViewForm.vue
@@ -65,6 +65,7 @@
     },
     methods: {
       async reload () {
+        console.log('>>> Form Reload!')
         const vm = this
         // 要支持外部更新 id 之后重载内容
         vm.id_ = vm.id


### PR DESCRIPTION
解决如下问题：
1. 新建页面保存的时候，并不能正确关闭编辑窗口；
2. 沉默了 EditView 相关的 Redundant Redicect 警告；
3. 将 EditView 的“保存”按钮改名为"保存并关闭"；
4. 解决了 EditView 创建后内部表单视图刷新不生效的问题；